### PR TITLE
ignore init module imports

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Remove unused imports with https://github.com/PyCQA/autoflake
       - uses: install-pinned/autoflake@46b4898323be58db319656fe2758f3fd5ddfee32
-      - run: autoflake --in-place --remove-all-unused-imports -r .
+      - run: autoflake --in-place --remove-all-unused-imports --ignore-init-module-imports -r .
 
       # Format code with https://github.com/psf/black
       - uses: install-pinned/black@01d6e39ad0779428fcdd976f6458e4c342cec66d


### PR DESCRIPTION
## exclude __init__.py when removing unused imports

>When I used the autofix action example, I found that the import of the init module was automatically removed; so I submitted a pr to help users with the same problem!

add `--ignore-init-module-imports`

https://github.com/Pactortester/diskq/pull/3/commits/775be7d5a03d81ff92e2f9400d3d48adf577a440

<img width="1122" alt="image" src="https://github.com/autofix-ci/autofix.ci/assets/29191106/670a045c-d776-4302-b22b-aeb5f35ae87a">
