### PR TITLE
docs: Improve install on GitHub link

### DIFF
--- a/index.html.jinja2
+++ b/index.html.jinja2
@@ -54,7 +54,7 @@
             automatically fixes pull requests to increase developer productivity.
         </h1>
 
-        <a id="install-button" target="_blank" href="https://github.com/apps/autofix-ci/installations/new"
+        <a id="install-button" target="_blank" href="https://github.com/marketplace/autofix-ci#pricing-and-setup"
            class="my-lg-3 shadow btn btn-lg d-inline-flex align-items-center">
             {{ icon("github") }}
             &nbsp;

--- a/index.html.jinja2
+++ b/index.html.jinja2
@@ -54,7 +54,7 @@
             automatically fixes pull requests to increase developer productivity.
         </h1>
 
-        <a id="install-button" target="_blank" href="https://github.com/marketplace/autofix-ci/plan/MLP_kgDNHxY#plan-7958"
+        <a id="install-button" target="_blank" href="https://github.com/apps/autofix-ci/installations/new"
            class="my-lg-3 shadow btn btn-lg d-inline-flex align-items-center">
             {{ icon("github") }}
             &nbsp;


### PR DESCRIPTION
I am not sure if this is a desired behavior, but:

- The links of "Install GitHub App" are different on https://autofix.ci/setup and the home page  https://autofix.ci/
- The link on the front page lead me to the plan dashboard of my personal account, where I was a bit lost of how to configure it for my other orgs (when I configured it for my personal account already)
- The link on https://autofix.ci/setup directly go to the orgs selection, which works much better for my need

I guess maybe you prefer to show the plans and did that on purpose? If so maybe add another button on the homepage like "Install for organizations"?

Thanks for your work on this! And no hard feeling to close this PR if it's not desired.