### PR TITLE
Fixed typo under Rust

### DIFF
--- a/setup.html.jinja2
+++ b/setup.html.jinja2
@@ -116,7 +116,7 @@
                     for example if you are using nightly rustfmt.
                 </p>
                 <p>
-                    Crab fact: <strong>autocix.ci's</strong> backend is written in Rust. 🦀
+                    Crab fact: <strong>autofix.ci's</strong> backend is written in Rust. 🦀
                 </p>
 
                 <h2 id="go">Go</h2>


### PR DESCRIPTION
Typo for rust's example 

P.S: love using autofix!